### PR TITLE
bson: add WithContext versions of API functions

### DIFF
--- a/bson/bson.go
+++ b/bson/bson.go
@@ -34,6 +34,7 @@ package bson
 
 import (
 	"bytes"
+	"context"
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/binary"
@@ -62,6 +63,10 @@ import (
 // will stop and error out with the provided value.
 type Getter interface {
 	GetBSON() (interface{}, error)
+}
+
+type GetterCtx interface {
+	GetBSONWithContext(context.Context) (interface{}, error)
 }
 
 // A value implementing the bson.Setter interface will receive the BSON
@@ -93,6 +98,10 @@ type Getter interface {
 //
 type Setter interface {
 	SetBSON(raw Raw) error
+}
+
+type SetterCtx interface {
+	SetBSONWithContext(ctx context.Context, raw Raw) error
 }
 
 // SetZero may be returned from a SetBSON method to have the value set to
@@ -279,7 +288,7 @@ var nullBytes = []byte("null")
 func (id *ObjectId) UnmarshalJSON(data []byte) error {
 	if len(data) > 0 && (data[0] == '{' || data[0] == 'O') {
 		var v struct {
-			Id json.RawMessage `json:"$oid"`
+			Id   json.RawMessage `json:"$oid"`
 			Func struct {
 				Id json.RawMessage
 			} `json:"$oidFunc"`
@@ -505,11 +514,15 @@ func handleErr(err *error) {
 //         F int64  "myf,omitempty,minsize"
 //     }
 //
-func Marshal(in interface{}) (out []byte, err error) {
+func MarshalWithContext(ctx context.Context, in interface{}) (out []byte, err error) {
 	defer handleErr(&err)
 	e := &encoder{make([]byte, 0, initialBufferSize)}
-	e.addDoc(reflect.ValueOf(in))
+	e.addDoc(ctx, reflect.ValueOf(in))
 	return e.out, nil
+}
+
+func Marshal(in interface{}) (out []byte, err error) {
+	return MarshalWithContext(context.TODO(), in)
 }
 
 // Unmarshal deserializes data from in into the out value.  The out value
@@ -547,7 +560,7 @@ func Marshal(in interface{}) (out []byte, err error) {
 // silently skipped.
 //
 // Pointer values are initialized when necessary.
-func Unmarshal(in []byte, out interface{}) (err error) {
+func UnmarshalWithContext(ctx context.Context, in []byte, out interface{}) (err error) {
 	if raw, ok := out.(*Raw); ok {
 		raw.Kind = 3
 		raw.Data = in
@@ -560,7 +573,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 		fallthrough
 	case reflect.Map:
 		d := newDecoder(in)
-		d.readDocTo(v)
+		d.readDocTo(ctx, v)
 	case reflect.Struct:
 		return errors.New("Unmarshal can't deal with struct values. Use a pointer.")
 	default:
@@ -569,12 +582,16 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 	return nil
 }
 
+func Unmarshal(in []byte, out interface{}) (err error) {
+	return UnmarshalWithContext(context.TODO(), in, out)
+}
+
 // Unmarshal deserializes raw into the out value.  If the out value type
 // is not compatible with raw, a *bson.TypeError is returned.
 //
 // See the Unmarshal function documentation for more details on the
 // unmarshalling process.
-func (raw Raw) Unmarshal(out interface{}) (err error) {
+func (raw Raw) UnmarshalWithContext(ctx context.Context, out interface{}) (err error) {
 	defer handleErr(&err)
 	v := reflect.ValueOf(out)
 	switch v.Kind() {
@@ -583,7 +600,7 @@ func (raw Raw) Unmarshal(out interface{}) (err error) {
 		fallthrough
 	case reflect.Map:
 		d := newDecoder(raw.Data)
-		good := d.readElemTo(v, raw.Kind)
+		good := d.readElemTo(ctx, v, raw.Kind)
 		if !good {
 			return &TypeError{v.Type(), raw.Kind}
 		}
@@ -593,6 +610,10 @@ func (raw Raw) Unmarshal(out interface{}) (err error) {
 		return errors.New("Raw Unmarshal needs a map or a valid pointer.")
 	}
 	return nil
+}
+
+func (raw Raw) Unmarshal(out interface{}) (err error) {
+	return raw.UnmarshalWithContext(context.TODO(), out)
 }
 
 type TypeError struct {

--- a/bson/context.go
+++ b/bson/context.go
@@ -1,0 +1,121 @@
+// BSON library for Go
+//
+// Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// gobson - BSON library for Go.
+//
+
+package bson
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type bsonOptions struct {
+	// skipCustom is used by
+	//   - decode.go to skip looking for a custom SetBSON() or SetBSONWithContext()
+	//   - encode.go to skip looking for a custom GetBSON() or GetBSONWithContext()
+	// for any type with the base type name specified by 'skipCustom'.
+	// This is useful to avoid infinite loop caused by:
+	//    - calling Unmarshal from custom SetBSON function (decode.go)
+	//    - encode.go calling custom GetBSON after just calling custom GetBSON for a given type
+	skipCustom string
+}
+
+type key int
+
+var bsonKey key = 0
+
+// Returns the topmost bsonOptions value stored in ctx, if any.
+func fromContext(ctx context.Context) (*bsonOptions, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	opts, ok := ctx.Value(bsonKey).(*bsonOptions)
+	return opts, ok
+}
+
+// Returns the base type name (type name without a prefix that contains any combination of * or []).
+func baseTypeName(typ reflect.Type) string {
+	return strings.Trim(fmt.Sprintf("%v", typ), "*[]")
+}
+
+// Creates a new context with a value for skipCustom based on base type name of valu.
+func NewContextWithSkipCustom(ctx context.Context, valu interface{}) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	//Debug(0, fmt.Sprintf("NewContextWithSkipCustom: %s", baseTypeName(reflect.TypeOf(valu))))
+	return context.WithValue(ctx, bsonKey, &bsonOptions{skipCustom: baseTypeName(reflect.TypeOf(valu))})
+}
+
+// IsSkipCustom is useful to avoid infinite loop caused by:
+//    - calling Unmarshal from custom SetBSON function (decode.go)
+//    - encode.go calling custom GetBSON after just calling custom GetBSON for a given type
+//
+// Returns true if base type name of typ is the same as skipCustom.
+//
+// This method is used to skip all custom SetBSON/GetBSON functions of all types with the same base type.
+// Note: if goal is to skip the custom functions of certain variations of a base type,
+// skipCustom will not work (it will skip all variants).
+func IsSkipCustom(ctx context.Context, typ reflect.Type) bool {
+	if opts, _ := fromContext(ctx); opts != nil {
+		//Debug(0, fmt.Sprintf("IsSkipCustom(%s) opts(%s) base(%s) %v", typ, opts.skipCustom,
+		//	baseTypeName(typ), opts.skipCustom == baseTypeName(typ)))
+		return opts.skipCustom == baseTypeName(typ)
+	}
+	//Debug(0, fmt.Sprintf("IsSkipCustom(%s) false", typ))
+	return false
+}
+
+// These were useful in debugging infinite loop issues:
+//    - calling Unmarshal from custom SetBSON function (decode.go)
+//    - encode.go calling custom GetBSON after just calling custom GetBSON for a given type
+// uncomment them (along with the invocations of Debug()) to aid debugging.
+//func valueType(valu reflect.Value) string {
+//	if !valu.IsValid() {
+//		return "Invalid"
+//	}
+//	return fmt.Sprintf("%s", valu.Type())
+//}
+//
+//var currentIndentLevel int = 0
+//var infinteLoopCounter int = 10000
+//
+//func Debug(delta int, msg string) {
+//	infinteLoopCounter--
+//	if infinteLoopCounter < 0 {
+//		panic(fmt.Errorf("YOU ARE IN INFINITE LOOP"))
+//	}
+//	if delta > 0 {
+//		currentIndentLevel += delta
+//	}
+//	fmt.Printf("%s%s\n", strings.Repeat(" ", currentIndentLevel), msg)
+//	if delta < 0 {
+//		currentIndentLevel += delta
+//	}
+//}

--- a/bson/context.go
+++ b/bson/context.go
@@ -69,7 +69,6 @@ func NewContextWithSkipCustom(ctx context.Context, valu interface{}) context.Con
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	//Debug(0, fmt.Sprintf("NewContextWithSkipCustom: %s", baseTypeName(reflect.TypeOf(valu))))
 	return context.WithValue(ctx, bsonKey, &bsonOptions{skipCustom: baseTypeName(reflect.TypeOf(valu))})
 }
 
@@ -84,38 +83,7 @@ func NewContextWithSkipCustom(ctx context.Context, valu interface{}) context.Con
 // skipCustom will not work (it will skip all variants).
 func IsSkipCustom(ctx context.Context, typ reflect.Type) bool {
 	if opts, _ := fromContext(ctx); opts != nil {
-		//Debug(0, fmt.Sprintf("IsSkipCustom(%s) opts(%s) base(%s) %v", typ, opts.skipCustom,
-		//	baseTypeName(typ), opts.skipCustom == baseTypeName(typ)))
 		return opts.skipCustom == baseTypeName(typ)
 	}
-	//Debug(0, fmt.Sprintf("IsSkipCustom(%s) false", typ))
 	return false
 }
-
-// These were useful in debugging infinite loop issues:
-//    - calling Unmarshal from custom SetBSON function (decode.go)
-//    - encode.go calling custom GetBSON after just calling custom GetBSON for a given type
-// uncomment them (along with the invocations of Debug()) to aid debugging.
-//func valueType(valu reflect.Value) string {
-//	if !valu.IsValid() {
-//		return "Invalid"
-//	}
-//	return fmt.Sprintf("%s", valu.Type())
-//}
-//
-//var currentIndentLevel int = 0
-//var infinteLoopCounter int = 10000
-//
-//func Debug(delta int, msg string) {
-//	infinteLoopCounter--
-//	if infinteLoopCounter < 0 {
-//		panic(fmt.Errorf("YOU ARE IN INFINITE LOOP"))
-//	}
-//	if delta > 0 {
-//		currentIndentLevel += delta
-//	}
-//	fmt.Printf("%s%s\n", strings.Repeat(" ", currentIndentLevel), msg)
-//	if delta < 0 {
-//		currentIndentLevel += delta
-//	}
-//}

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -83,16 +83,10 @@ type encoder struct {
 }
 
 func (e *encoder) addDoc(ctx context.Context, v reflect.Value) {
-	//cnt := 0
-	//Debug(4, fmt.Sprintf("addDoc(%v)-A", valueType(v)))
-	//defer func() {
-	//	Debug(-4, fmt.Sprintf("addDoc(%v)-Z", valueType(v)))
-	//}()
 	for {
 		//cnt += 1
 		if !IsSkipCustom(ctx, v.Type()) {
 			if vi, ok := v.Interface().(GetterCtx); ok {
-				//Debug(0, fmt.Sprintf("addDoc(%02d)-GetterCtx(%v)", cnt, valueType(v)))
 				getv, err := vi.GetBSONWithContext(ctx)
 				if err != nil {
 					panic(err)
@@ -102,7 +96,6 @@ func (e *encoder) addDoc(ctx context.Context, v reflect.Value) {
 				continue
 			}
 			if vi, ok := v.Interface().(Getter); ok {
-				//Debug(0, fmt.Sprintf("addDoc(%02d)-Getter(%v)", cnt, valueType(v)))
 				getv, err := vi.GetBSON()
 				if err != nil {
 					panic(err)
@@ -118,7 +111,6 @@ func (e *encoder) addDoc(ctx context.Context, v reflect.Value) {
 		}
 		break
 	}
-	//Debug(0, fmt.Sprintf("addDoc(%v)-B", valueType(v)))
 
 	if v.Type() == typeRaw {
 		raw := v.Interface().(Raw)
@@ -132,7 +124,6 @@ func (e *encoder) addDoc(ctx context.Context, v reflect.Value) {
 		return
 	}
 
-	//Debug(0, fmt.Sprintf("addDoc(%v)-C", valueType(v)))
 	start := e.reserveInt32()
 
 	switch v.Kind() {
@@ -224,10 +215,6 @@ func isZero(v reflect.Value) bool {
 }
 
 func (e *encoder) addSlice(ctx context.Context, v reflect.Value) {
-	//Debug(4, fmt.Sprintf("addSlice(%v)-A", valueType(v)))
-	//defer func() {
-	//	Debug(-4, fmt.Sprintf("addSlice(%v)-Z", valueType(v)))
-	//}()
 	vi := v.Interface()
 	if d, ok := vi.(D); ok {
 		for _, elem := range d {
@@ -272,20 +259,13 @@ func (e *encoder) addElemName(kind byte, name string) {
 }
 
 func (e *encoder) addElem(ctx context.Context, name string, v reflect.Value, minSize bool) {
-	//Debug(4, fmt.Sprintf("addElem(%v)[%v]-A", valueType(v), name))
-	//defer func() {
-	//	Debug(-4, fmt.Sprintf("addElem(%v)[%v]-Z", valueType(v), name))
-	//}()
-
 	if !v.IsValid() {
 		e.addElemName(0x0A, name)
 		return
 	}
 
-	//Debug(0, fmt.Sprintf("addElem(%v)-B", valueType(v)))
 	if !IsSkipCustom(ctx, v.Type()) {
 		if getter, ok := v.Interface().(GetterCtx); ok {
-			//Debug(0, fmt.Sprintf("addElem-GetterCtx(%v)", valueType(v)))
 			getv, err := getter.GetBSONWithContext(ctx)
 			if err != nil {
 				panic(err)
@@ -295,7 +275,6 @@ func (e *encoder) addElem(ctx context.Context, name string, v reflect.Value, min
 			return
 		}
 		if getter, ok := v.Interface().(Getter); ok {
-			//Debug(0, fmt.Sprintf("addElem-Getter(%v)", valueType(v)))
 			getv, err := getter.GetBSON()
 			if err != nil {
 				panic(err)
@@ -306,7 +285,6 @@ func (e *encoder) addElem(ctx context.Context, name string, v reflect.Value, min
 		}
 	}
 
-	//Debug(0, fmt.Sprintf("addElem(%v)-C", valueType(v)))
 	switch v.Kind() {
 
 	case reflect.Interface:

--- a/bson/encode.go
+++ b/bson/encode.go
@@ -28,6 +28,7 @@
 package bson
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -81,15 +82,35 @@ type encoder struct {
 	out []byte
 }
 
-func (e *encoder) addDoc(v reflect.Value) {
+func (e *encoder) addDoc(ctx context.Context, v reflect.Value) {
+	//cnt := 0
+	//Debug(4, fmt.Sprintf("addDoc(%v)-A", valueType(v)))
+	//defer func() {
+	//	Debug(-4, fmt.Sprintf("addDoc(%v)-Z", valueType(v)))
+	//}()
 	for {
-		if vi, ok := v.Interface().(Getter); ok {
-			getv, err := vi.GetBSON()
-			if err != nil {
-				panic(err)
+		//cnt += 1
+		if !IsSkipCustom(ctx, v.Type()) {
+			if vi, ok := v.Interface().(GetterCtx); ok {
+				//Debug(0, fmt.Sprintf("addDoc(%02d)-GetterCtx(%v)", cnt, valueType(v)))
+				getv, err := vi.GetBSONWithContext(ctx)
+				if err != nil {
+					panic(err)
+				}
+				v = reflect.ValueOf(getv)
+				ctx = NewContextWithSkipCustom(ctx, getv)
+				continue
 			}
-			v = reflect.ValueOf(getv)
-			continue
+			if vi, ok := v.Interface().(Getter); ok {
+				//Debug(0, fmt.Sprintf("addDoc(%02d)-Getter(%v)", cnt, valueType(v)))
+				getv, err := vi.GetBSON()
+				if err != nil {
+					panic(err)
+				}
+				v = reflect.ValueOf(getv)
+				ctx = NewContextWithSkipCustom(ctx, getv)
+				continue
+			}
 		}
 		if v.Kind() == reflect.Ptr {
 			v = v.Elem()
@@ -97,6 +118,7 @@ func (e *encoder) addDoc(v reflect.Value) {
 		}
 		break
 	}
+	//Debug(0, fmt.Sprintf("addDoc(%v)-B", valueType(v)))
 
 	if v.Type() == typeRaw {
 		raw := v.Interface().(Raw)
@@ -110,15 +132,16 @@ func (e *encoder) addDoc(v reflect.Value) {
 		return
 	}
 
+	//Debug(0, fmt.Sprintf("addDoc(%v)-C", valueType(v)))
 	start := e.reserveInt32()
 
 	switch v.Kind() {
 	case reflect.Map:
-		e.addMap(v)
+		e.addMap(ctx, v)
 	case reflect.Struct:
-		e.addStruct(v)
+		e.addStruct(ctx, v)
 	case reflect.Array, reflect.Slice:
-		e.addSlice(v)
+		e.addSlice(ctx, v)
 	default:
 		panic("Can't marshal " + v.Type().String() + " as a BSON document")
 	}
@@ -127,13 +150,13 @@ func (e *encoder) addDoc(v reflect.Value) {
 	e.setInt32(start, int32(len(e.out)-start))
 }
 
-func (e *encoder) addMap(v reflect.Value) {
+func (e *encoder) addMap(ctx context.Context, v reflect.Value) {
 	for _, k := range v.MapKeys() {
-		e.addElem(k.String(), v.MapIndex(k), false)
+		e.addElem(ctx, k.String(), v.MapIndex(k), false)
 	}
 }
 
-func (e *encoder) addStruct(v reflect.Value) {
+func (e *encoder) addStruct(ctx context.Context, v reflect.Value) {
 	sinfo, err := getStructInfo(v.Type())
 	if err != nil {
 		panic(err)
@@ -147,7 +170,7 @@ func (e *encoder) addStruct(v reflect.Value) {
 				if _, found := sinfo.FieldsMap[ks]; found {
 					panic(fmt.Sprintf("Can't have key %q in inlined map; conflicts with struct field", ks))
 				}
-				e.addElem(ks, m.MapIndex(k), false)
+				e.addElem(ctx, ks, m.MapIndex(k), false)
 			}
 		}
 	}
@@ -160,7 +183,7 @@ func (e *encoder) addStruct(v reflect.Value) {
 		if info.OmitEmpty && isZero(value) {
 			continue
 		}
-		e.addElem(info.Key, value, info.MinSize)
+		e.addElem(ctx, info.Key, value, info.MinSize)
 	}
 }
 
@@ -200,17 +223,21 @@ func isZero(v reflect.Value) bool {
 	return false
 }
 
-func (e *encoder) addSlice(v reflect.Value) {
+func (e *encoder) addSlice(ctx context.Context, v reflect.Value) {
+	//Debug(4, fmt.Sprintf("addSlice(%v)-A", valueType(v)))
+	//defer func() {
+	//	Debug(-4, fmt.Sprintf("addSlice(%v)-Z", valueType(v)))
+	//}()
 	vi := v.Interface()
 	if d, ok := vi.(D); ok {
 		for _, elem := range d {
-			e.addElem(elem.Name, reflect.ValueOf(elem.Value), false)
+			e.addElem(ctx, elem.Name, reflect.ValueOf(elem.Value), false)
 		}
 		return
 	}
 	if d, ok := vi.(RawD); ok {
 		for _, elem := range d {
-			e.addElem(elem.Name, reflect.ValueOf(elem.Value), false)
+			e.addElem(ctx, elem.Name, reflect.ValueOf(elem.Value), false)
 		}
 		return
 	}
@@ -219,19 +246,19 @@ func (e *encoder) addSlice(v reflect.Value) {
 	if et == typeDocElem {
 		for i := 0; i < l; i++ {
 			elem := v.Index(i).Interface().(DocElem)
-			e.addElem(elem.Name, reflect.ValueOf(elem.Value), false)
+			e.addElem(ctx, elem.Name, reflect.ValueOf(elem.Value), false)
 		}
 		return
 	}
 	if et == typeRawDocElem {
 		for i := 0; i < l; i++ {
 			elem := v.Index(i).Interface().(RawDocElem)
-			e.addElem(elem.Name, reflect.ValueOf(elem.Value), false)
+			e.addElem(ctx, elem.Name, reflect.ValueOf(elem.Value), false)
 		}
 		return
 	}
 	for i := 0; i < l; i++ {
-		e.addElem(itoa(i), v.Index(i), false)
+		e.addElem(ctx, itoa(i), v.Index(i), false)
 	}
 }
 
@@ -244,29 +271,49 @@ func (e *encoder) addElemName(kind byte, name string) {
 	e.addBytes(0)
 }
 
-func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
+func (e *encoder) addElem(ctx context.Context, name string, v reflect.Value, minSize bool) {
+	//Debug(4, fmt.Sprintf("addElem(%v)[%v]-A", valueType(v), name))
+	//defer func() {
+	//	Debug(-4, fmt.Sprintf("addElem(%v)[%v]-Z", valueType(v), name))
+	//}()
 
 	if !v.IsValid() {
 		e.addElemName(0x0A, name)
 		return
 	}
 
-	if getter, ok := v.Interface().(Getter); ok {
-		getv, err := getter.GetBSON()
-		if err != nil {
-			panic(err)
+	//Debug(0, fmt.Sprintf("addElem(%v)-B", valueType(v)))
+	if !IsSkipCustom(ctx, v.Type()) {
+		if getter, ok := v.Interface().(GetterCtx); ok {
+			//Debug(0, fmt.Sprintf("addElem-GetterCtx(%v)", valueType(v)))
+			getv, err := getter.GetBSONWithContext(ctx)
+			if err != nil {
+				panic(err)
+			}
+			v = reflect.ValueOf(getv)
+			e.addElem(NewContextWithSkipCustom(ctx, getv), name, v, minSize)
+			return
 		}
-		e.addElem(name, reflect.ValueOf(getv), minSize)
-		return
+		if getter, ok := v.Interface().(Getter); ok {
+			//Debug(0, fmt.Sprintf("addElem-Getter(%v)", valueType(v)))
+			getv, err := getter.GetBSON()
+			if err != nil {
+				panic(err)
+			}
+			v = reflect.ValueOf(getv)
+			e.addElem(NewContextWithSkipCustom(ctx, getv), name, v, minSize)
+			return
+		}
 	}
 
+	//Debug(0, fmt.Sprintf("addElem(%v)-C", valueType(v)))
 	switch v.Kind() {
 
 	case reflect.Interface:
-		e.addElem(name, v.Elem(), minSize)
+		e.addElem(ctx, name, v.Elem(), minSize)
 
 	case reflect.Ptr:
-		e.addElem(name, v.Elem(), minSize)
+		e.addElem(ctx, name, v.Elem(), minSize)
 
 	case reflect.String:
 		s := v.String()
@@ -348,7 +395,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 
 	case reflect.Map:
 		e.addElemName(0x03, name)
-		e.addDoc(v)
+		e.addDoc(ctx, v)
 
 	case reflect.Slice:
 		vt := v.Type()
@@ -358,10 +405,10 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 			e.addBinary(0x00, v.Bytes())
 		} else if et == typeDocElem || et == typeRawDocElem {
 			e.addElemName(0x03, name)
-			e.addDoc(v)
+			e.addDoc(ctx, v)
 		} else {
 			e.addElemName(0x04, name)
-			e.addDoc(v)
+			e.addDoc(ctx, v)
 		}
 
 	case reflect.Array:
@@ -381,7 +428,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 			}
 		} else {
 			e.addElemName(0x04, name)
-			e.addDoc(v)
+			e.addDoc(ctx, v)
 		}
 
 	case reflect.Struct:
@@ -429,7 +476,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 				e.addElemName(0x0F, name)
 				start := e.reserveInt32()
 				e.addStr(s.Code)
-				e.addDoc(reflect.ValueOf(s.Scope))
+				e.addDoc(ctx, reflect.ValueOf(s.Scope))
 				e.setInt32(start, int32(len(e.out)-start))
 			}
 
@@ -447,7 +494,7 @@ func (e *encoder) addElem(name string, v reflect.Value, minSize bool) {
 
 		default:
 			e.addElemName(0x03, name)
-			e.addDoc(v)
+			e.addDoc(ctx, v)
 		}
 
 	default:

--- a/session.go
+++ b/session.go
@@ -1011,7 +1011,7 @@ type indexSpec struct {
 	DefaultLanguage  string  "default_language,omitempty"
 	LanguageOverride string  "language_override,omitempty"
 	TextIndexVersion int     "textIndexVersion,omitempty"
-
+	PartialFilterExpression  bson.M "partialFilterExpression,omitempty"
 	Collation *Collation "collation,omitempty"
 }
 
@@ -1021,6 +1021,7 @@ type Index struct {
 	DropDups   bool     // Drop documents with the same index key as a previously indexed one
 	Background bool     // Build index in background and return immediately
 	Sparse     bool     // Only index documents containing the Key fields
+	PartialFilterExpression bson.M //If specified, the index only references documents that match the filter expression
 
 	// If ExpireAfter is defined the server will periodically delete
 	// documents with indexed time.Time older than the provided delta.
@@ -1284,6 +1285,7 @@ func (c *Collection) EnsureIndex(index Index) error {
 		DropDups:         index.DropDups,
 		Background:       index.Background,
 		Sparse:           index.Sparse,
+		PartialFilterExpression: index.PartialFilterExpression,
 		Bits:             index.Bits,
 		Min:              index.Minf,
 		Max:              index.Maxf,
@@ -1494,20 +1496,21 @@ func (c *Collection) Indexes() (indexes []Index, err error) {
 
 func indexFromSpec(spec indexSpec) Index {
 	index := Index{
-		Name:             spec.Name,
-		Key:              simpleIndexKey(spec.Key),
-		Unique:           spec.Unique,
-		DropDups:         spec.DropDups,
-		Background:       spec.Background,
-		Sparse:           spec.Sparse,
-		Minf:             spec.Min,
-		Maxf:             spec.Max,
-		Bits:             spec.Bits,
-		BucketSize:       spec.BucketSize,
-		DefaultLanguage:  spec.DefaultLanguage,
-		LanguageOverride: spec.LanguageOverride,
-		ExpireAfter:      time.Duration(spec.ExpireAfter) * time.Second,
-		Collation:        spec.Collation,
+		Name:                    spec.Name,
+		Key:                     simpleIndexKey(spec.Key),
+		Unique:                  spec.Unique,
+		DropDups:                spec.DropDups,
+		Background:              spec.Background,
+		Sparse:                  spec.Sparse,
+		Minf:                    spec.Min,
+		Maxf:                    spec.Max,
+		Bits:                    spec.Bits,
+		BucketSize:              spec.BucketSize,
+		DefaultLanguage:         spec.DefaultLanguage,
+		LanguageOverride:        spec.LanguageOverride,
+		ExpireAfter:             time.Duration(spec.ExpireAfter) * time.Second,
+		Collation:               spec.Collation,
+		PartialFilterExpression: spec.PartialFilterExpression,
 	}
 	if float64(int(spec.Min)) == spec.Min && float64(int(spec.Max)) == spec.Max {
 		index.Min = int(spec.Min)

--- a/session_test.go
+++ b/session_test.go
@@ -2975,6 +2975,21 @@ var indexTests = []struct {
 		"key":  M{"cn": 1},
 		"ns":   "mydb.mycoll",
 	},
+}, {
+	mgo.Index{
+		Key:        []string{"p"},
+		Unique: true,
+		PartialFilterExpression: bson.M{
+			"p": bson.M{"$exists": true},
+		},
+	},
+	M{
+		"name":       "p_1",
+		"key":        M{"p": 1},
+		"ns":         "mydb.mycoll",
+		"unique":   true,
+		"partialFilterExpression": M{"p" : M{"$exists" : true}},
+	},
 }}
 
 func (s *S) TestEnsureIndex(c *C) {


### PR DESCRIPTION
- Marshal
  - if GetBSON() returned the same object it was passed, encode.go would turn around
    and call add*() function on that same object causing an infinite loop. Using
    NewContextWithSkipCustom() avoids infinite loop (avoids calling GetBSON() again).
    Returning the same object is useful in the case where GetBSON():
      - obtains bson.Raw from fields hidden (annotations) from the standard marshaler
      - sets bson.Raw fields visible (annotations) to the standard marshaler
      - returns the same object such that standard marshalling can occur
  - context.Context can be used to control how fields are marshaled

- Unmarshal
  - calling Unmarshal on the same object from SetBSON() would cause infinite loop
  - fix: pass bson.NewContextWithSkipCustom(ctx, obj) to UnmarshalWithContext()
  - context.Context can be used to control how fields are unmarshaled